### PR TITLE
Bump version of Sidekiq-Cron

### DIFF
--- a/lib/sidekiq/cron/tasks/version.rb
+++ b/lib/sidekiq/cron/tasks/version.rb
@@ -1,7 +1,7 @@
 module Sidekiq
   module Cron
     module Tasks
-      VERSION = "0.4.0".freeze
+      VERSION = "0.4.1".freeze
     end
   end
 end

--- a/sidekiq-cron-tasks.gemspec
+++ b/sidekiq-cron-tasks.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "railties", ">= 4.1.0", "< 6.0"
   s.add_dependency "capistrano-rails", "~> 1.1"
-  s.add_dependency "sidekiq-cron", ">= 0.4", "< 0.7"
+  s.add_dependency "sidekiq-cron", ">= 0.4", "< 1.1"
   s.add_dependency "capistrano", ">= 3.4", "< 4.0"
 end


### PR DESCRIPTION
Now `Sidekiq-Cron`'s latest version is `1.0.4`.
https://github.com/ondrejbartas/sidekiq-cron/releases

So current `sidekiq-cron-tasks.gemspec` causes dependencies error as below.

- Gemfile

```Gemfile
gem 'sidekiq-cron', "~> 1.0.4"
gem 'sidekiq-cron-tasks'
```

- `bundle install`

```bash
$ bundle install --path vendor/bundle
Resolving dependencies...
Bundler could not find compatible versions for gem "sidekiq-cron":
  In Gemfile:
    sidekiq-cron (~> 1.0.4)

    sidekiq-cron-tasks was resolved to 0.4.0, which depends on
      sidekiq-cron (< 0.7, >= 0.4)
```

This PR modifies it.